### PR TITLE
[PD-2302] Add support for new zevm endpoints 

### DIFF
--- a/apps/block_scout_web/assets/js/lib/smart_contract/interact.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/interact.js
@@ -102,6 +102,19 @@ function onTransactionHash (txHash, functionName) {
           openSuccessModal('Success', successMsg)
           clearInterval(txReceiptPollingIntervalId)
         }
+      }).catch(error => {
+        console.log(error)
+        window.ethereum.request({
+          method: 'zevm_getTransactionReceipt',
+          params: [txHash]
+        })
+          .then(txReceipt => {
+            if (txReceipt) {
+              const successMsg = `Successfully sent <a href="/tx/${txHash}">transaction</a> for method "${functionName}"`
+              openSuccessModal('Success', successMsg)
+              clearInterval(txReceiptPollingIntervalId)
+            }
+          })
       })
   }
   const txReceiptPollingIntervalId = setInterval(() => { getTxReceipt(txHash) }, 5 * 1000)

--- a/apps/block_scout_web/assets/package-lock.json
+++ b/apps/block_scout_web/assets/package-lock.json
@@ -100,10 +100,11 @@
       }
     },
     "../../../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.5.13",
+      "license": "MIT"
     },
     "../../../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "3.0.4"
     },
     "node_modules/@amplitude/analytics-browser": {
       "version": "1.6.1",

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block/zevm_by_number.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block/zevm_by_number.ex
@@ -1,0 +1,11 @@
+defmodule EthereumJSONRPC.Block.ZEvmByNumber do
+  @moduledoc """
+  Block format as returned by [`zevm_getBlockByNumber`]
+  """
+
+  import EthereumJSONRPC, only: [integer_to_quantity: 1]
+
+  def request(%{id: id, number: number}) do
+    EthereumJSONRPC.request(%{id: id, method: "zevm_getBlockByNumber", params: [integer_to_quantity(number), true]})
+  end
+end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block/zevm_by_tag.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block/zevm_by_tag.ex
@@ -1,0 +1,23 @@
+defmodule EthereumJSONRPC.Block.ZEvmByTag do
+  @moduledoc """
+  Block format returned by [`zevm_getBlockByNumber`]
+  when used with a semantic tag name instead of a number.
+  """
+
+  import EthereumJSONRPC, only: [quantity_to_integer: 1]
+
+  def request(%{id: id, tag: tag}) when is_binary(tag) do
+    EthereumJSONRPC.request(%{id: id, method: "zevm_getBlockByNumber", params: [tag, false]})
+  end
+
+  def number_from_result({:ok, %{"number" => nil}}), do: {:error, :not_found}
+
+  def number_from_result({:ok, %{"number" => quantity}}) when is_binary(quantity) do
+    {:ok, quantity_to_integer(quantity)}
+  end
+
+  def number_from_result({:ok, nil}), do: {:error, :not_found}
+
+  def number_from_result({:error, %{"code" => -32602}}), do: {:error, :invalid_tag}
+  def number_from_result({:error, _} = error), do: error
+end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
@@ -2,19 +2,78 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
   @moduledoc """
   Uses `HTTPoison` for `EthereumJSONRPC.HTTP`
   """
+  require Logger
 
   alias EthereumJSONRPC.HTTP
 
   @behaviour HTTP
 
+  def contains_zevm_request(json) do
+    String.contains? Kernel.inspect(json) , "zevm"
+  end
+
   @impl HTTP
   def json_rpc(url, json, options) when is_binary(url) and is_list(options) do
-    case HTTPoison.post(url, json, [{"Content-Type", "application/json"}], options) do
-      {:ok, %HTTPoison.Response{body: body, status_code: status_code}} ->
-        {:ok, %{body: body, status_code: status_code}}
+    if !contains_zevm_request(json) do
+      case HTTPoison.post(url, json, [{"Content-Type", "application/json"}], options) do
+        {:ok, %HTTPoison.Response{body: body, status_code: status_code}} ->
+          {:ok, %{body: body, status_code: status_code}}
 
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        {:error, reason}
+        {:error, %HTTPoison.Error{reason: reason}} ->
+          {:error, reason}
+      end
+    else
+      # Custom rpc endpoints does not allow batch requests
+      {:ok, list} = Jason.decode(json)
+
+      # todo (@Martin): fix this part.
+
+      responses = Enum.map(list,
+                        fn request -> (
+                          if (request[:method] != nil && String.contains? request[:method] , "zevm") do
+                            [path_param | _tail] = (if  is_map(request) && Map.has_key?(request, :params), do: request[:params], else: [])
+                            zevm_path = "zeta-chain/zevm/" <> request[:method] <> (if path_param != nil, do:  "/" <> path_param, else: "")
+                            zevm_url = (if (String.contains? request[:method] , "zevm"), do: String.replace(url, "evm", zevm_path), else: url)
+
+                            HTTPoison.get(zevm_url, [], options)
+                          else
+                            HTTPoison.post(url, Jason.encode_to_iodata!(request), [{"Content-Type", "application/json"}], options)
+                          end
+                        ) end)
+
+      successes = responses
+                    |> Enum.filter(fn res -> case res do
+                      {:ok, _other} ->
+                        true
+
+                      {:error, _other} ->
+                        false
+                    end end)
+                    |> Enum.map(fn res ->
+                      {:ok, %HTTPoison.Response{body: body}} = res
+                      body end)
+
+      errors = responses
+                |> Enum.filter(fn res -> case res do
+                  {:ok, _other} ->
+                    false
+
+                  {:error, _other} ->
+                    true
+                end  end)
+                |> Enum.map(fn res ->
+                  {:error, %HTTPoison.Error{reason: reason}} = res
+                    reason end)
+
+      Logger.info "responses " <> inspect(responses)
+      Logger.info "successes " <> inspect(successes)
+      Logger.info "errors " <> inspect(errors)
+
+      if length(errors) > 0 do
+        {:error, errors}
+      else
+        {:ok, %{body: responses, status_code: 200}}
+      end
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -501,10 +501,14 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
               transaction_receipt_from_node =
                 fetch_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments)
 
-              if elem(transaction_receipt_from_node, 0) != :ok do
-                transaction_receipt_from_node =
+              transaction_receipt_from_node = if (
+                elem(transaction_receipt_from_node, 0) != :ok
+                or length(elem(transaction_receipt_from_node,1)[:receipts]) == 0
+              ) do
                   fetch_zevm_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments)
-              end
+                else
+                  transaction_receipt_from_node
+                end
 
               update_transactions_inner(
                 repo,
@@ -532,10 +536,14 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
               transaction_receipt_from_node =
                 fetch_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments)
 
-              if elem(transaction_receipt_from_node, 0) != :ok do
-                transaction_receipt_from_node =
+              transaction_receipt_from_node = if (
+                elem(transaction_receipt_from_node, 0) != :ok
+                or length(elem(transaction_receipt_from_node,1)[:receipts]) == 0
+              ) do
                   fetch_zevm_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments)
-              end
+                else
+                  transaction_receipt_from_node
+                end
 
               update_transactions_inner(
                 repo,

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -501,6 +501,11 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
               transaction_receipt_from_node =
                 fetch_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments)
 
+              if elem(transaction_receipt_from_node, 0) != :ok do
+                transaction_receipt_from_node =
+                  fetch_zevm_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments)
+              end
+
               update_transactions_inner(
                 repo,
                 valid_internal_transactions,
@@ -526,6 +531,11 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
             true ->
               transaction_receipt_from_node =
                 fetch_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments)
+
+              if elem(transaction_receipt_from_node, 0) != :ok do
+                transaction_receipt_from_node =
+                  fetch_zevm_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments)
+              end
 
               update_transactions_inner(
                 repo,
@@ -560,6 +570,32 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
   defp fetch_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments) do
     receipt_response =
       EthereumJSONRPC.fetch_transaction_receipts(
+        [
+          %{
+            :hash => to_string(transaction_hash),
+            :gas => 0
+          }
+        ],
+        json_rpc_named_arguments
+      )
+
+    case receipt_response do
+      {:ok,
+       %{
+         :receipts => [
+           receipt
+         ]
+       }} ->
+        receipt
+
+      _ ->
+        %{:cumulative_gas_used => nil}
+    end
+  end
+
+  defp fetch_zevm_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments) do
+    receipt_response =
+      EthereumJSONRPC.fetch_zevm_transaction_receipts(
         [
           %{
             :hash => to_string(transaction_hash),

--- a/apps/explorer/lib/explorer/chain_spec/geth/importer.ex
+++ b/apps/explorer/lib/explorer/chain_spec/geth/importer.ex
@@ -21,6 +21,7 @@ defmodule Explorer.ChainSpec.Geth.Importer do
 
     json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
 
+    # Getting timestamp, no need to add zevm blocks data
     {:ok, %Blocks{blocks_params: [%{timestamp: timestamp}]}} =
       EthereumJSONRPC.fetch_blocks_by_range(1..1, json_rpc_named_arguments)
 

--- a/apps/explorer/lib/explorer/chain_spec/parity/importer.ex
+++ b/apps/explorer/lib/explorer/chain_spec/parity/importer.ex
@@ -37,6 +37,7 @@ defmodule Explorer.ChainSpec.Parity.Importer do
 
     json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
 
+    # Getting timestamp, no need to add zevm blocks data
     {:ok, %Blocks{blocks_params: [%{timestamp: timestamp}]}} =
       EthereumJSONRPC.fetch_blocks_by_range(1..1, json_rpc_named_arguments)
 

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -129,6 +129,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
     Application.get_env(:indexer, __MODULE__)[:concurrency]
   end
 
+  # Getting block number, no need to add zevm blocks data
   defp fetch_last_block(json_rpc_named_arguments) do
     case latest_block() do
       nil ->
@@ -392,6 +393,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
           {:ok, [last_block()..(latest_block_number - 1)]}
         end
 
+      # Getting block ranges, no need to add zevm blocks data
       num ->
         with {:ok, latest_block_number} <-
                EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments) do

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -111,6 +111,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
      }}
   end
 
+  # Getting block number, no need to add zevm blocks data
   @impl GenServer
   def handle_info(
         :poll_latest_block_number,

--- a/apps/indexer/lib/indexer/fetcher/coin_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance.ex
@@ -227,6 +227,7 @@ defmodule Indexer.Fetcher.CoinBalance do
       |> Enum.sort()
       |> Enum.dedup()
 
+    # Getting timestamp, no need to add zevm blocks data
     Enum.reduce(block_numbers, %{}, fn block_number, map ->
       case EthereumJSONRPC.fetch_blocks_by_range(block_number..block_number, json_rpc_named_arguments) do
         {:ok, %Blocks{blocks_params: [%{timestamp: timestamp}]}} ->

--- a/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
+++ b/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
@@ -77,7 +77,7 @@ defmodule Indexer.PendingTransactionsSanitizer do
              %{id: ind, method: "eth_getTransactionReceipt", params: [pending_tx_hash_str]}
              |> request()
              |> json_rpc(json_rpc_named_arguments) do
-        if result do
+        if result and Map.get(result, "blockHash") do
           block_hash = Map.get(result, "blockHash")
 
           if block_hash do

--- a/apps/indexer/lib/indexer/transform/address_coin_balances_daily.ex
+++ b/apps/indexer/lib/indexer/transform/address_coin_balances_daily.ex
@@ -27,6 +27,7 @@ defmodule Indexer.Transform.AddressCoinBalancesDaily do
           else
             json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
 
+            # Just getting timestamp, no need to use zevm_getBlockByNumber
             with {:ok, %{"timestamp" => timestamp_raw}} <-
                    %{id: 1, method: "eth_getBlockByNumber", params: [integer_to_quantity(block_number), false]}
                    |> request()

--- a/apps/indexer/lib/indexer/transform/addresses.ex
+++ b/apps/indexer/lib/indexer/transform/addresses.ex
@@ -432,9 +432,17 @@ defmodule Indexer.Transform.Addresses do
           (entity_items = Map.get(fetched_data, entity_key)) != nil,
           do: extract_addresses_from_collection(entity_items, entity_fields, state)
 
-    addresses
-    |> List.flatten()
-    |> merge_addresses()
+
+    a = addresses
+      |> List.flatten()
+      |> merge_addresses()
+
+    if (a == nil) do
+      IO.puts "NIL"
+      IO.inspect(fetched_data)
+    end
+
+    a
   end
 
   def extract_addresses_from_collection(items, fields, state),


### PR DESCRIPTION
## Context
Since the beginning of zetachain we have EthereumTx executed by the fungible module (non EOA) and those ones are not being exposed by standards eth_getBlockByNumber (txs) nor eth_getTransactionReceipt endpoints. Therefore, standard blockscout indexer does not 'see' state changes made by those txs (e.g. token balance change) and we have inconsistent information.

Discussion: https://zetachain.slack.com/archives/D03RX4JU95J/p1664987393006029?thread_ts=1664916420.155719&cid=D03RX4JU95J

Solution: Add new read-only endpoints that exposes those txs and read from them.

Issue: https://github.com/zeta-chain/zeta-node/issues/348

## Changes in this PR
Adds methods to read from those new endpoints (zevm_getBlockByNumber and zevm_getTransactionReceipt) and for each block gets also these zevm txs.

Disclaimer: blockscout is coded in Elixir, and since we don't have  much knowledge in elixir this PR may not have the best practices (e.g. is easier/safer to copy an existing function instead of refactoring and reuse the same code adding new types). 


## Next steps
Redeploy blockscout instance using this code and reindex from block zero.

ClosesPD-2302